### PR TITLE
Return a request map if it doesn't have accept-language

### DIFF
--- a/src/ring/middleware/accept_language.clj
+++ b/src/ring/middleware/accept_language.clj
@@ -38,7 +38,8 @@
   (if-let [header (get-in request [:headers "accept-language"])]
     (let [values (parse-header header)
           accept (into {} (map parse-accept values))]
-      (assoc request :accept-language accept))))
+      (assoc request :accept-language accept))
+    request))
 
 (defn wrap-accept-language [handler]
   (comp handler accept-language-request))

--- a/test/ring/middleware/accept_language_test.clj
+++ b/test/ring/middleware/accept_language_test.clj
@@ -23,9 +23,9 @@
       (is (= result {"ja" 1.0}))))
   (testing "No accept-language"
     (let [request {:headers {"host" "localhost"}}
-          retuened-request (al/accept-language-request request)
-          result (:accept-language retuened-request)]
-      (is (= request retuened-request))
+          returned-request (al/accept-language-request request)
+          result (:accept-language returned-request)]
+      (is (= request returned-request))
       (is (= result nil))))
   (testing "No requests"
     (let [result (:accept-language (al/accept-language-request {}))]

--- a/test/ring/middleware/accept_language_test.clj
+++ b/test/ring/middleware/accept_language_test.clj
@@ -22,8 +22,10 @@
                                                "ja")))]
       (is (= result {"ja" 1.0}))))
   (testing "No accept-language"
-    (let [result (:accept-language (al/accept-language-request
-                                     {:headers {"host" "localhost"}}))]
+    (let [request {:headers {"host" "localhost"}}
+          retuened-request (al/accept-language-request request)
+          result (:accept-language retuened-request)]
+      (is (= request retuened-request))
       (is (= result nil))))
   (testing "No requests"
     (let [result (:accept-language (al/accept-language-request {}))]


### PR DESCRIPTION
## Issues
If a request map doesn't have accept-language, it changes nil.

## Fixes
* Fix a function handling so that returns a request map if it doesn't have accept-language